### PR TITLE
Apply repository conventions

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = 'Stop'
 Push-Location $PSScriptRoot
 try {
-	dotnet publish ./tools/Build/Build.csproj --artifacts-path ./artifacts --nologo --verbosity quiet
+	dotnet publish ./tools/Build/Build.csproj --artifacts-path ./artifacts --nologo --verbosity quiet -tl:off
 	if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 	dotnet ./artifacts/publish/Build/release/Build.dll $args
 	if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
Conventions applied by [repo-conventions](https://github.com/Faithlife/RepoConventions):
- [faithlife-csharp-library](https://github.com/Faithlife/CodingGuidelines/tree/HEAD/conventions/faithlife-csharp-library)
  - [faithlife-build-script](https://github.com/Faithlife/CodingGuidelines/tree/HEAD/conventions/faithlife-build-script)